### PR TITLE
Remove Ghosting

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -208,6 +208,7 @@
 	UnregisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP)
 	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/show_join_button)
 
+/*
 /atom/movable/screen/lobby/button/observe
 	screen_loc = "TOP:-40,CENTER:-54"
 	icon = 'icons/hud/lobby/observe.dmi'
@@ -234,6 +235,7 @@
 	flick("[base_icon_state]_enabled", src)
 	set_button_status(TRUE)
 	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, .proc/enable_observing)
+*/
 
 /atom/movable/screen/lobby/button/settings
 	icon = 'icons/hud/lobby/bottom_buttons.dmi'

--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -30,7 +30,7 @@
 	fugitive.forceMove(src)
 	antag.is_captured = TRUE
 	to_chat(fugitive, span_userdanger("You are thrown into a vast void of bluespace, and as you fall further into oblivion the comparatively small entrance to reality gets smaller and smaller until you cannot see it anymore. You have failed to avoid capture."))
-	fugitive.ghostize(TRUE) //so they cannot suicide, round end stuff.
+	fugitive.ghostize(FALSE) //so they cannot suicide, round end stuff.
 
 /obj/machinery/computer/shuttle/hunter
 	name = "shuttle console"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -93,8 +93,10 @@
 		var/datum/poll_question/poll = locate(href_list["votepollref"]) in GLOB.polls
 		vote_on_poll_handler(poll, href_list)
 
+/*
 //When you cop out of the round (NB: this HAS A SLEEP FOR PLAYER INPUT IN IT)
 /mob/dead/new_player/proc/make_me_an_observer()
+
 	if(QDELETED(src) || !src.client)
 		ready = PLAYER_NOT_READY
 		return FALSE
@@ -131,6 +133,7 @@
 	QDEL_NULL(mind)
 	qdel(src)
 	return TRUE
+*/
 
 /proc/get_job_unavailable_error_message(retval, jobtitle)
 	switch(retval)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -279,10 +279,13 @@ Transfer_mind is there to check if mob is being deleted/not going to have a body
 Works together with spawning an observer, noted above.
 */
 
-/mob/proc/ghostize(can_reenter_corpse = TRUE)
+/mob/proc/ghostize(can_reenter_corpse = FALSE)
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
 			if(HAS_TRAIT(src, TRAIT_CORPSELOCKED) && can_reenter_corpse) //If you can re-enter the corpse you can't leave when corpselocked
+				return
+			if(!can_reenter_corpse)
+				abandon_mob_respawn()
 				return
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
 			var/mob/dead/observer/ghost = new(src) // Transfer safety to observer spawning proc.
@@ -290,11 +293,9 @@ Works together with spawning an observer, noted above.
 			ghost.can_reenter_corpse = can_reenter_corpse
 			ghost.key = key
 			ghost.client?.init_verbs()
-			if(!can_reenter_corpse)// Disassociates observer mind from the body mind
-				ghost.mind = null
 			return ghost
 
-/mob/living/ghostize(can_reenter_corpse = TRUE)
+/mob/living/ghostize(can_reenter_corpse = FALSE)
 	. = ..()
 	if(. && can_reenter_corpse)
 		var/mob/dead/observer/ghost = .
@@ -303,6 +304,7 @@ Works together with spawning an observer, noted above.
 /*
 This is the proc mobs get to turn into a ghost. Forked from ghostize due to compatibility issues.
 */
+/*
 /mob/living/verb/ghost()
 	set category = "OOC"
 	set name = "Ghost"
@@ -328,6 +330,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(response != "Ghost")
 		return
 	ghostize(FALSE)
+*/
 
 /mob/dead/observer/Move(NewLoc, direct, glide_size_override = 32)
 	if(updatedir)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -78,7 +78,7 @@
 		deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 		if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client?.holder)
 			to_chat(src, span_deadsay(span_big("Observer freelook is disabled.\nPlease use Orbit, Teleport, and Jump to look around.")))
-			ghostize(TRUE)
+			ghostize(FALSE)
 	set_drugginess(0)
 	set_disgust(0)
 	SetSleeping(0, 0)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1027,6 +1027,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		update_appearance()
 		. = TRUE
 
+/*
 /mob/living/simple_animal/bot/ghost()
 	if(stat != DEAD) // Only ghost if we're doing this while alive, the pAI probably isn't dead yet.
 		return ..()
@@ -1035,6 +1036,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/sentience_act()
 	faction -= "silicon"
+*/
 
 /mob/living/simple_animal/bot/proc/set_path(list/newpath)
 	path = newpath ? newpath : list()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -525,10 +525,12 @@
 			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 			visible_message(span_notice("[src] mends the wounds of [target]."),span_notice("You mend the wounds of [target]."))
 
+/*
 /mob/living/simple_animal/hostile/lightgeist/ghost()
 	. = ..()
 	if(.)
 		death()
+*/
 
 /obj/machinery/anomalous_crystal/possessor //Allows you to bodyjack small animals, then exit them at your leisure, but you can only do this once per activation. Because they blow up. Also, if the bodyjacked animal dies, SO DO YOU.
 	observer_desc = "When activated, this crystal allows you to take over small animals, and then exit them at the possessors leisure. Exiting the animal kills it, and if you die while possessing the animal, you die as well."

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -212,7 +212,7 @@
 		//This entire if/else chain could be in two lines but isn't for readibilties sake.
 		var/msg = message
 		var/msg_type = MSG_VISUAL
-		
+
 		if(M.see_invisible < invisibility)//if src is invisible to M
 			msg = blind_message
 			msg_type = MSG_AUDIBLE
@@ -687,13 +687,13 @@
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (CONFIG_GET(flag/norespawn) && (!check_rights_for(usr.client, R_ADMIN) || tgui_alert(usr, "Respawn configs disabled. Do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes"))
-		return
-
 	if ((stat != DEAD || !( SSticker )))
 		to_chat(usr, span_boldnotice("You must be dead to use this!"))
 		return
 
+	abandon_mob_respawn()
+
+/mob/proc/abandon_mob_respawn()
 	log_game("[key_name(usr)] used the respawn button.")
 
 	to_chat(usr, span_boldnotice("Please roleplay correctly!"))
@@ -1040,7 +1040,7 @@
 	if(!istext(newname) && !isnull(newname))
 		stack_trace("[src] attempted to change its name from [oldname] to the non string value [newname]")
 		return FALSE
-		
+
 	log_message("[src] name changed from [oldname] to [newname]", LOG_OWNERSHIP)
 
 	log_played_names(ckey, newname)
@@ -1334,7 +1334,7 @@
 /mob/proc/become_uncliented()
 	if(!canon_client)
 		return
-		
+
 	for(var/foo in canon_client.player_details.post_logout_callbacks)
 		var/datum/callback/CB = foo
 		CB.Invoke()

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -374,10 +374,13 @@
 		qdel(src)
 	else if(timetokill <= 0)
 		to_chat(captured, span_boldnotice("As the last essence of your being is erased from time, you are taken back to your most enjoyable memory. You feel happy..."))
+
+		captured.ghostize(0)
+		/*
 		var/mob/dead/observer/ghost = captured.ghostize(1)
 		if(captured.mind)
 			if(ghost)
-				ghost.mind = null
+				ghost.mind = null		*/
 		qdel(captured)
 		qdel(src)
 	else

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -165,7 +165,7 @@
 	var/mob/living/carbon/jedi = user
 	to_chat(jedi, span_userdanger("That was a shockingly dumb idea."))
 	var/obj/item/organ/brain/rip_u = locate(/obj/item/organ/brain) in jedi.internal_organs
-	jedi.ghostize(jedi)
+	jedi.ghostize(0)
 	if(rip_u)
 		qdel(rip_u)
 	jedi.death()

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -121,7 +121,7 @@
 /obj/structure/table/abductor/wabbajack/proc/sleeper_dreams(mob/living/sleeper)
 	if(sleeper in sleepers)
 		to_chat(sleeper, span_revennotice("While you slumber, you have the strangest dream, like you can see yourself from the outside."))
-		sleeper.ghostize(TRUE)
+		sleeper.ghostize(FALSE)
 
 /obj/structure/table/abductor/wabbajack/left
 	desc = "You sleep so it may wake."


### PR DESCRIPTION
Ghost verb and the Observe button removed.

ghostize() and ghostize(FALSE) now return player to lobby.
ghostize(TRUE) ghosts as normal and is reserved for AGhost (keeping functionality just in case).

This PR is not modular since we don't plan on keeping up with upstream. Please review before merging in case of bugs.

:cl:
del: Ghosting removed
/:cl:
